### PR TITLE
Fix deprecations

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('playbloom_guzzle');
+        $treeBuilder = new TreeBuilder('playbloom_guzzle');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ First, define your own `GithubDataCollector` extending the `Playbloom\Bundle\Guz
 
 Then extends the guzzle web profiler template
 ```twig
-{% extends 'PlaybloomGuzzleBundle:Collector:guzzle.html.twig' %}
+{% extends '@PlaybloomGuzzle/Collector/guzzle.html.twig' %}
 
 {% block panel %}
     <div class="github">
@@ -94,7 +94,7 @@ Then extends the guzzle web profiler template
         </ul>
     </div>
 
-    {% include 'PlaybloomGuzzleBundle:Profiler:requests.html.twig' with {'requests': collector.requests } %}
+    {% include '@PlaybloomGuzzle/Profiler/requests.html.twig' with {'requests': collector.requests } %}
 {% endblock %}
 ```
 
@@ -103,7 +103,7 @@ And finally declare your data collector
 <service id="data_collector.github" class="Acme\GithubBundle\DataCollector\GithubDataCollector">
     <argument type="service" id="playbloom_guzzle.client.plugin.profiler"/>
     <tag name="data_collector"
-        template="AcmeGithubBundle:Collector:github"
+        template="@AcmeGithub/Collector/github"
         id="github"/>
 </service>
 ```

--- a/Resources/config/datacollector.xml
+++ b/Resources/config/datacollector.xml
@@ -8,7 +8,7 @@
         <service id="data_collector.guzzle" class="Playbloom\Bundle\GuzzleBundle\DataCollector\CompositeGuzzleDataCollector">
             <argument type="service" id="data_collector.guzzle_3"/>
             <argument type="service" id="data_collector.guzzle_5"/>
-            <tag name="data_collector" template="PlaybloomGuzzleBundle:Collector:guzzle" id="guzzle"/>
+            <tag name="data_collector" template="@PlaybloomGuzzle/Collector/guzzle" id="guzzle"/>
         </service>
 
         <service id="data_collector.guzzle_3" class="Playbloom\Bundle\GuzzleBundle\DataCollector\Guzzle3DataCollector">

--- a/Resources/views/Collector/guzzle.html.twig
+++ b/Resources/views/Collector/guzzle.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% if collector.calls is empty %}
@@ -34,7 +34,7 @@
         </div>
     {% endset %}
 
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': 'guzzle' } %}
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': 'guzzle' } %}
 {% endblock %}
 
 {% block menu %}
@@ -62,5 +62,5 @@
 {% block panel %}
     <h2>{{ (collector.name|capitalize)|default('HTTP calls') }}</h2>
 
-    {% include 'PlaybloomGuzzleBundle:Profiler:calls.html.twig' with {'calls': collector.calls } %}
+    {% include '@PlaybloomGuzzle/Profiler/calls.html.twig' with {'calls': collector.calls } %}
 {% endblock %}

--- a/Resources/views/Profiler/call.html.twig
+++ b/Resources/views/Profiler/call.html.twig
@@ -19,13 +19,13 @@
             <div class="tab">
                 <h3 class="tab-title">Request</h3>
                 <div class="tab-content">
-                    {% include 'PlaybloomGuzzleBundle:Profiler:request.html.twig' with {index: index, request: call.request, time: call.time, trace: call.trace|default([]) } %}
+                    {% include '@PlaybloomGuzzle/Profiler/request.html.twig' with {index: index, request: call.request, time: call.time, trace: call.trace|default([]) } %}
                 </div>
             </div>
             <div class="tab">
                 <h3 class="tab-title">Response</h3>
                 <div class="tab-content">
-                    {% include 'PlaybloomGuzzleBundle:Profiler:response.html.twig' with {index: index, response: call.response} %}
+                    {% include '@PlaybloomGuzzle/Profiler/response.html.twig' with {index: index, response: call.response} %}
                 </div>
             </div>
         </div>

--- a/Resources/views/Profiler/calls.html.twig
+++ b/Resources/views/Profiler/calls.html.twig
@@ -1,7 +1,7 @@
 <div class="guzzle">
     <h2>Requests</h2>
     {% for index, call in calls %}
-        {% include 'PlaybloomGuzzleBundle:Profiler:call.html.twig' with { 'call': call } %}
+        {% include '@PlaybloomGuzzle/Profiler/call.html.twig' with { 'call': call } %}
     {% endfor %}
 </div>
-{% include 'PlaybloomGuzzleBundle:Profiler:javascript.html.twig' %}
+{% include '@PlaybloomGuzzle/Profiler/javascript.html.twig' %}


### PR DESCRIPTION
This PR fixes the deprecated TreeBuilder usage and the template path syntax from
`PlaybloomGuzzleBundle:Collector:guzzle.html.twig`   
to   
`@PlaybloomGuzzle/Collector/guzzle.html.twig`   
in order to get compatibility to the `@twig` service, which should be used in favor of the `@templating` service.